### PR TITLE
M+フォントに関係するREADMEとLICENSEファイルの追加

### DIFF
--- a/LICENSE_E.mplus
+++ b/LICENSE_E.mplus
@@ -1,0 +1,16 @@
+M+ FONTS                                Copyright (C) 2002-2012 M+ FONTS PROJECT
+
+-
+
+LICENSE_E
+
+
+
+
+These fonts are free software.
+Unlimited permission is granted to use, copy, and distribute them, with
+or without modification, either commercially or noncommercially.
+THESE FONTS ARE PROVIDED "AS IS" WITHOUT WARRANTY.
+
+
+http://mplus-fonts.sourceforge.jp/mplus-outline-fonts/

--- a/LICENSE_J.mplus
+++ b/LICENSE_J.mplus
@@ -1,0 +1,15 @@
+M+ FONTS                                Copyright (C) 2002-2012 M+ FONTS PROJECT
+
+-
+
+LICENSE_J
+
+
+
+
+これらのフォントはフリー（自由な）ソフトウエアです。
+あらゆる改変の有無に関わらず、また商業的な利用であっても、自由にご利用、
+複製、再配布することができますが、全て無保証とさせていただきます。
+
+
+http://mplus-fonts.sourceforge.jp/

--- a/README_E.mplus
+++ b/README_E.mplus
@@ -1,0 +1,82 @@
+M+ FONTS                                Copyright (C) 2002-2012 M+ FONTS PROJECT
+
+-
+
+README_E
+
+
+
+
+M+ TESTFLIGHT
+
+The M+ OUTLINE FONTS are distributed with proportional Latin (4 variations), fixed-halfwidth Latin (3 variations) and fixed-fullwidth Japanese (2 Kana variations) character set. 7 weights from Thin to Black are included, but fixed-halfwidth Latin with 5 weights from Thin to Bold.
+
+
+PROPORTIONAL FONTS (proportional Latin and fixed-fullwidth Japanese)
+
+M+ 1P     mplus-1p-thin.ttf
+          mplus-1p-light.ttf
+          mplus-1p-regular.ttf
+          mplus-1p-medium.ttf
+          mplus-1p-bold.ttf
+          mplus-1p-heavy.ttf
+          mplus-1p-black.ttf
+          
+M+ 2P     mplus-2p-thin.ttf
+          mplus-2p-light.ttf
+          mplus-2p-regular.ttf
+          mplus-2p-medium.ttf
+          mplus-2p-bold.ttf
+          mplus-2p-heavy.ttf
+          mplus-2p-black.ttf
+          
+M+ 1C     mplus-1c-thin.ttf
+          mplus-1c-light.ttf
+          mplus-1c-regular.ttf
+          mplus-1c-medium.ttf
+          mplus-1c-bold.ttf
+          mplus-1c-heavy.ttf
+          mplus-1c-black.ttf
+          
+M+ 2C     mplus-2c-thin.ttf
+          mplus-2c-light.ttf
+          mplus-2c-regular.ttf
+          mplus-2c-medium.ttf
+          mplus-2c-bold.ttf
+          mplus-2c-heavy.ttf
+          mplus-2c-black.ttf
+
+
+FIXED-WIDTH FONTS (fixed-halfwidth Latin and fixed-fullwidth Japanese)
+
+M+ 1M     mplus-1m-thin.ttf
+          mplus-1m-light.ttf
+          mplus-1m-regular.ttf
+          mplus-1m-medium.ttf
+          mplus-1m-bold.ttf
+          
+M+ 2M     mplus-2m-thin.ttf
+          mplus-2m-light.ttf
+          mplus-2m-regular.ttf
+          mplus-2m-medium.ttf
+          mplus-2m-bold.ttf
+
+M+ 1MN    mplus-1mn-thin.ttf
+          mplus-1mn-light.ttf
+          mplus-1mn-regular.ttf
+          mplus-1mn-medium.ttf
+          mplus-1mn-bold.ttf
+
+          
+
+
+-
+
+M+ OUTLINE FONTS
+http://mplus-fonts.sourceforge.jp/mplus-outline-fonts/
+
+mplus-fonts-dev ML
+http://lists.sourceforge.jp/mailman/listinfo/mplus-fonts-dev
+
+M+ FONTS open forum
+http://sourceforge.jp/forum/forum.php?forum_id=3403

--- a/README_J.mplus
+++ b/README_J.mplus
@@ -1,0 +1,90 @@
+M+ FONTS                                Copyright (C) 2002-2012 M+ FONTS PROJECT
+
+-
+
+README_J
+
+
+
+
+M+ TESTFLIGHT
+
+M+ OUTLINE FONTS は 2 種類のかな文字を持つ固定幅和文フォントと 4 種類の
+プロポーショナル欧文フォント、3 種類の半角固定幅欧文フォントの組み合わせから
+構成され、それぞれ Thin から Black まで 7 種類（半角固定幅フォントは Bold
+まで 5 種類）のウエイトバリエーションがあります。
+
+
+プロポーショナルフォント（和文は全角固定幅、欧文・数字はプロポーショナル）
+
+M+ 1P     mplus-1p-thin.ttf
+          mplus-1p-light.ttf
+          mplus-1p-regular.ttf
+          mplus-1p-medium.ttf
+          mplus-1p-bold.ttf
+          mplus-1p-heavy.ttf
+          mplus-1p-black.ttf
+          
+M+ 2P     mplus-2p-thin.ttf
+          mplus-2p-light.ttf
+          mplus-2p-regular.ttf
+          mplus-2p-medium.ttf
+          mplus-2p-bold.ttf
+          mplus-2p-heavy.ttf
+          mplus-2p-black.ttf
+          
+M+ 1C     mplus-1c-thin.ttf
+          mplus-1c-light.ttf
+          mplus-1c-regular.ttf
+          mplus-1c-medium.ttf
+          mplus-1c-bold.ttf
+          mplus-1c-heavy.ttf
+          mplus-1c-black.ttf
+          
+M+ 2C     mplus-2c-thin.ttf
+          mplus-2c-light.ttf
+          mplus-2c-regular.ttf
+          mplus-2c-medium.ttf
+          mplus-2c-bold.ttf
+          mplus-2c-heavy.ttf
+          mplus-2c-black.ttf
+
+
+固定幅フォント（和文は全角、欧文・数字は半角の固定幅）
+
+M+ 1M     mplus-1m-thin.ttf
+          mplus-1m-light.ttf
+          mplus-1m-regular.ttf
+          mplus-1m-medium.ttf
+          mplus-1m-bold.ttf
+          
+M+ 2M     mplus-2m-thin.ttf
+          mplus-2m-light.ttf
+          mplus-2m-regular.ttf
+          mplus-2m-medium.ttf
+          mplus-2m-bold.ttf
+
+M+ 1MN    mplus-1mn-thin.ttf
+          mplus-1mn-light.ttf
+          mplus-1mn-regular.ttf
+          mplus-1mn-medium.ttf
+          mplus-1mn-bold.ttf
+
+          
+
+
+かな文字と常用漢字、基本的な欧文グリフが揃い、一般的な文章の大半の文字を表示
+できるようになりました。不足している文字は他のフォントからの自動補完、
+IPAG フォントとの合成などで補うことができます。
+M+ OUTLINE FONTS の詳細、お問い合わせなどは以下の URL からお願いします。
+
+-
+
+M+ OUTLINE FONTS
+http://mplus-fonts.sourceforge.jp/mplus-outline-fonts/
+
+mplus-fonts-dev ML
+http://lists.sourceforge.jp/mailman/listinfo/mplus-fonts-dev
+
+M+ FONTS open forum
+http://sourceforge.jp/forum/forum.php?forum_id=3403


### PR DESCRIPTION
debianパッケージをする時にM+フォントのREADMEとLICENSEがupstreamに入っていると便利だなぁという動機によるプルリクです。
